### PR TITLE
Added wake up request to the API

### DIFF
--- a/assets/js/warmup.js
+++ b/assets/js/warmup.js
@@ -1,0 +1,11 @@
+$(document).ready(function ($) {
+    function wake_heroku() {
+        var settings = {
+            url: "https://eltrak.herokuapp.com/",
+            method: "GET",
+            timeout: 0,
+        };
+        $.ajax(settings);
+    }
+    wake_heroku();
+});

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
     <!--JS-->
 
     <script src="./assets/js/main.js"></script>
+    <script src="./assets/js/warmup.js"></script>
   </head>
   <body>
     <section id="header">


### PR DESCRIPTION
Due to Heroku policies, the Dyno hosting the API is idle when not in use. This results in slower response times for the first search, due to the container's boot overhead.
I attempted to mitigate this problem by sending an empty request to the API every time the page loads. This triggers the spawn of the Dyno before the actual tracking request and hopefully reduces the initial response time. 